### PR TITLE
Updating rails stable versions

### DIFF
--- a/src/officialVersions.js
+++ b/src/officialVersions.js
@@ -8,7 +8,7 @@ export const officialVersions = {
   },
   rails: {
     latest: '6.1.3.2',
-    stables: ['6.0.3.7', '5.2.6'],
+    stables: ['6.0.4', '5.2.6'],
   },
   sinatra: {
     latest: '2.1.0',


### PR DESCRIPTION
🛤    Rails 6.0.4 has been released 

https://weblog.rubyonrails.org/2021/6/15/Rails-6-0-4-has-been-released/